### PR TITLE
Synchronize operations on sendChanRefCount map

### DIFF
--- a/network.go
+++ b/network.go
@@ -84,6 +84,8 @@ type Graph struct {
 	connections []connection
 	// sendChanRefCount tracks how many sendports use the same channel
 	sendChanRefCount map[uintptr]uint
+	// sendChanMutex is used to synchronize operations on the sendChanRefCount map.
+	sendChanMutex sync.Locker
 	// iips contains initial IPs attached to the network
 	iips []iip
 	// done is used to let the outside world know when the net has finished its job
@@ -102,6 +104,7 @@ func (n *Graph) InitGraphState() {
 	n.outPorts = make(map[string]port, DefaultNetworkPortsNum)
 	n.connections = make([]connection, 0, DefaultNetworkCapacity)
 	n.sendChanRefCount = make(map[uintptr]uint, DefaultNetworkCapacity)
+	n.sendChanMutex = new(sync.Mutex)
 	n.iips = make([]iip, 0, DefaultNetworkPortsNum)
 	n.done = make(chan struct{})
 	n.ready = make(chan struct{})
@@ -131,6 +134,9 @@ func init() {
 
 // Increments SendChanRefCount
 func (n *Graph) IncSendChanRefCount(c reflect.Value) {
+	n.sendChanMutex.Lock()
+	defer n.sendChanMutex.Unlock()
+
 	ptr := c.Pointer()
 	cnt := n.sendChanRefCount[ptr]
 	cnt += 1
@@ -140,6 +146,9 @@ func (n *Graph) IncSendChanRefCount(c reflect.Value) {
 // Decrements SendChanRefCount
 // It returns true if the RefCount has reached 0
 func (n *Graph) DecSendChanRefCount(c reflect.Value) bool {
+	n.sendChanMutex.Lock()
+	defer n.sendChanMutex.Unlock()
+
 	ptr := c.Pointer()
 	cnt := n.sendChanRefCount[ptr]
 	if cnt == 0 {


### PR DESCRIPTION
It may happen that multiple concurrent `DecSendChanRefCount()` calls turn into a data race condition when accessing/changing the `sendChanRefCount` map, since [maps are not thread-safe](https://blog.golang.org/go-maps-in-action#TOC_6.). This particular situation arises when shutting down a network that has a structure of multiple components sending output to another single component and between themselves, generating a warning when running our unit tests using the `-race` argument.

The proposed fix consists in synchronizing the operations over the map with a mutex. This PR also includes a test that it's relatively consistent in showing such warning (if the fix isn't applied of course):

```
C:\test\src\github.com\trustmaster\goflow>go test -v -race -run TestNetWithNTo1Components
=== RUN   TestNetWithNTo1Components
==================
WARNING: DATA RACE
Read by goroutine 11:
  runtime.mapaccess1_fast64()
      C:/workdir/go/src/runtime/hashmap_fast.go:95 +0x0
  github.com/trustmaster/goflow.(*Graph).DecSendChanRefCount()
      C:/test/src/github.com/trustmaster/goflow/network.go:144 +0x97
  github.com/trustmaster/goflow.RunProc.func4()
      C:/test/src/github.com/trustmaster/goflow/component.go:200 +0x385
  github.com/trustmaster/goflow.RunProc.func5()
      C:/test/src/github.com/trustmaster/goflow/component.go:235 +0x1e3
  github.com/trustmaster/goflow.RunProc.func8()
      C:/test/src/github.com/trustmaster/goflow/component.go:322 +0x65
 
Previous write by goroutine 9:
  runtime.mapassign1()
      C:/workdir/go/src/runtime/hashmap.go:411 +0x0
  github.com/trustmaster/goflow.(*Graph).DecSendChanRefCount()
      C:/test/src/github.com/trustmaster/goflow/network.go:149 +0x130
  github.com/trustmaster/goflow.RunProc.func4()
      C:/test/src/github.com/trustmaster/goflow/component.go:200 +0x385
  github.com/trustmaster/goflow.RunProc.func5()
      C:/test/src/github.com/trustmaster/goflow/component.go:235 +0x1e3
  github.com/trustmaster/goflow.RunProc.func8()
      C:/test/src/github.com/trustmaster/goflow/component.go:322 +0x65
 
Goroutine 11 (running) created at:
  github.com/trustmaster/goflow.RunProc()
      C:/test/src/github.com/trustmaster/goflow/component.go:331 +0x1f80
  github.com/trustmaster/goflow.(*Graph).run()
      C:/test/src/github.com/trustmaster/goflow/network.go:639 +0x12c1
  github.com/trustmaster/goflow.RunNet.func1()
      C:/test/src/github.com/trustmaster/goflow/network.go:922 +0x39
 
Goroutine 9 (finished) created at:
  github.com/trustmaster/goflow.RunProc()
      C:/test/src/github.com/trustmaster/goflow/component.go:331 +0x1f80
  github.com/trustmaster/goflow.(*Graph).run()
      C:/test/src/github.com/trustmaster/goflow/network.go:639 +0x12c1
  github.com/trustmaster/goflow.RunNet.func1()
      C:/test/src/github.com/trustmaster/goflow/network.go:922 +0x39
==================
--- PASS: TestNetWithNTo1Components (0.08s)
PASS
Found 1 data race(s)
exit status 66
FAIL    github.com/trustmaster/goflow   1.171s
```