### PR TITLE
Connect refactor to enable array ports

### DIFF
--- a/graph_connect.go
+++ b/graph_connect.go
@@ -147,10 +147,7 @@ func attachPort(port reflect.Value, dir reflect.ChanDir, ch reflect.Value, bufSi
 	if err := validateCanSet(port); err != nil {
 		return ch, err
 	}
-	ch, err := selectOrMakeChan(ch, port, bufSize)
-	if err != nil {
-		return ch, err
-	}
+	ch = selectOrMakeChan(ch, port, bufSize)
 	port.Set(ch)
 	return ch, nil
 }
@@ -173,15 +170,15 @@ func validateCanSet(portVal reflect.Value) error {
 	return nil
 }
 
-func selectOrMakeChan(new, existing reflect.Value, bufSize int) (reflect.Value, error) {
+func selectOrMakeChan(new, existing reflect.Value, bufSize int) reflect.Value {
 	if !new.IsValid() || new.IsNil() {
 		if existing.IsValid() && !existing.IsNil() {
-			return existing, nil
+			return existing
 		}
 		chanType := reflect.ChanOf(reflect.BothDir, existing.Type().Elem())
 		new = reflect.MakeChan(chanType, bufSize)
 	}
-	return new, nil
+	return new
 }
 
 // parseAddress unfolds a string port name into parts, including array index or hashmap key

--- a/graph_connect_test.go
+++ b/graph_connect_test.go
@@ -28,37 +28,37 @@ func TestConnectInvalidParams(t *testing.T) {
 		{
 			"Invalid receiver proc",
 			n.Connect("e1", "Out", "noproc", "In"),
-			"connect: getProcPort: process 'noproc' not found",
+			"connect: process 'noproc' not found",
 		},
 		{
 			"Invalid receiver port",
 			n.Connect("e1", "Out", "e2", "NotIn"),
-			"connect: getProcPort: process 'e2' does not have port 'NotIn'",
+			"connect: process 'e2' does not have port 'NotIn'",
 		},
 		{
 			"Invalid sender proc",
 			n.Connect("noproc", "Out", "e2", "In"),
-			"connect: getProcPort: process 'noproc' not found",
+			"connect: process 'noproc' not found",
 		},
 		{
 			"Invalid sender port",
 			n.Connect("e1", "NotOut", "e2", "In"),
-			"connect: getProcPort: process 'e1' does not have port 'NotOut'",
+			"connect: process 'e1' does not have port 'NotOut'",
 		},
 		{
 			"Sending to output",
 			n.Connect("e1", "Out", "e2", "Out"),
-			"connect: validation of 'e2.Out' failed: channel does not support direction <-chan",
+			"connect 'e2.Out': channel does not support direction <-chan",
 		},
 		{
 			"Sending from input",
 			n.Connect("e1", "In", "e2", "In"),
-			"connect: validation of 'e1.In' failed: channel does not support direction chan<-",
+			"connect 'e1.In': channel does not support direction chan<-",
 		},
 		{
 			"Connecting to non-chan",
 			n.Connect("e1", "Out", "inv", "NotChan"),
-			"connect: validation of 'inv.NotChan' failed: not a channel",
+			"connect 'inv.NotChan': not a channel",
 		},
 	}
 

--- a/graph_connect_test.go
+++ b/graph_connect_test.go
@@ -28,37 +28,37 @@ func TestConnectInvalidParams(t *testing.T) {
 		{
 			"Invalid receiver proc",
 			n.Connect("e1", "Out", "noproc", "In"),
-			"Connect error: process 'noproc' not found",
+			"connect: getProcPort: process 'noproc' not found",
 		},
 		{
 			"Invalid receiver port",
 			n.Connect("e1", "Out", "e2", "NotIn"),
-			"Connect error: process 'e2' does not have port 'NotIn'",
+			"connect: getProcPort: process 'e2' does not have port 'NotIn'",
 		},
 		{
 			"Invalid sender proc",
 			n.Connect("noproc", "Out", "e2", "In"),
-			"Connect error: process 'noproc' not found",
+			"connect: getProcPort: process 'noproc' not found",
 		},
 		{
 			"Invalid sender port",
 			n.Connect("e1", "NotOut", "e2", "In"),
-			"Connect error: process 'e1' does not have port 'NotOut'",
+			"connect: getProcPort: process 'e1' does not have port 'NotOut'",
 		},
 		{
 			"Sending to output",
 			n.Connect("e1", "Out", "e2", "Out"),
-			"Connect error: 'e2.Out' is not of the correct chan type",
+			"connect: validation of 'e2.Out' failed: channel does not support direction <-chan",
 		},
 		{
 			"Sending from input",
 			n.Connect("e1", "In", "e2", "In"),
-			"Connect error: 'e1.In' is not of the correct chan type",
+			"connect: validation of 'e1.In' failed: channel does not support direction chan<-",
 		},
 		{
 			"Connecting to non-chan",
 			n.Connect("e1", "Out", "inv", "NotChan"),
-			"Connect error: 'inv.NotChan' is not of the correct chan type",
+			"connect: validation of 'inv.NotChan' failed: not a channel",
 		},
 	}
 


### PR DESCRIPTION
Refactors the Connect logic to be less complex and more extensible/maintainable. This is required to as a first step to support new types of ports: Array ports and Map ports.