### PR TITLE
Enable ineffassign, errcheck except in tests, minor refactoring

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -357,6 +357,7 @@ linters:
     - bodyclose
     - depguard
     - dogsled
+    - errcheck
     - exhaustive
     - exportloopref
     - funlen
@@ -366,6 +367,7 @@ linters:
     - goimports
     - gomodguard
     - goprintffuncname
+    - ineffassign
     - interfacer
     - maligned
     - misspell
@@ -382,7 +384,6 @@ linters:
   disable:
     - deadcode
     - dupl
-    - errcheck
     - gocognit
     - gocyclo
     - godot
@@ -390,7 +391,6 @@ linters:
     - goerr113
     - gofumpt
     - gomnd
-    - ineffassign
     - lll
     - nestif
     - nlreturn
@@ -421,7 +421,7 @@ issues:
     - path: _test\.go
       linters:
         # - gocyclo
-        # - errcheck
+        - errcheck
         # - dupl
         - gosec
 

--- a/graph_iip.go
+++ b/graph_iip.go
@@ -43,7 +43,7 @@ func (n *Graph) sendIIPs() error {
 
 		// Get the receiver port channel
 		var channel reflect.Value
-		var found bool
+		found := false
 
 		// Try to find it among network inports
 		for j := range n.inPorts {
@@ -65,7 +65,7 @@ func (n *Graph) sendIIPs() error {
 			}
 		}
 
-		var shouldClose bool
+		shouldClose := false
 
 		if !found {
 			// Try to find a proc and attach a new channel to it


### PR DESCRIPTION
- `errcheck` only fails in tests, so enabled elsewhere
- `inefassign` only had one issue, fixed by returning an error
- slightly improved `sendIIPs()` while I was at it (keep normal flow indentation at minimum by handling error conditions early; do not use iterating variables in a goroutine, which is unsafe)