### PR TITLE
Enable wsl linter for better readability

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -381,6 +381,7 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - wsl
   disable:
     - deadcode
     - dupl
@@ -399,7 +400,6 @@ linters:
     - stylecheck
     - testpackage
     - unused
-    - wsl
 
   disable-all: false
   # presets:

--- a/component.go
+++ b/component.go
@@ -14,10 +14,12 @@ type Wait chan struct{}
 // Run the component process
 func Run(c Component) Wait {
 	wait := make(Wait)
+
 	go func() {
 		c.Process()
 		wait <- Done{}
 	}()
+
 	return wait
 }
 
@@ -33,6 +35,7 @@ func NewInputGuard(ports ...string) *InputGuard {
 	for _, p := range ports {
 		portMap[p] = false
 	}
+
 	return &InputGuard{portMap, 0}
 }
 
@@ -42,5 +45,6 @@ func (g *InputGuard) Complete(port string) bool {
 		g.ports[port] = true
 		g.complete++
 	}
+
 	return g.complete >= len(g.ports)
 }

--- a/component_test.go
+++ b/component_test.go
@@ -16,6 +16,7 @@ func TestSimpleComponent(t *testing.T) {
 	wait := Run(c)
 
 	in <- 12
+
 	res := <-out
 
 	if res != 24 {
@@ -43,6 +44,7 @@ func TestSimpleLongRunningComponent(t *testing.T) {
 
 	for src, expected := range data {
 		in <- src
+
 		actual := <-out
 
 		if actual != expected {
@@ -71,6 +73,7 @@ func TestComponentWithTwoInputs(t *testing.T) {
 		for _, n := range op1 {
 			in1 <- n
 		}
+
 		close(in1)
 	}()
 
@@ -78,12 +81,14 @@ func TestComponentWithTwoInputs(t *testing.T) {
 		for _, n := range op2 {
 			in2 <- n
 		}
+
 		close(in2)
 	}()
 
 	for i := 0; i < len(sums); i++ {
 		actual := <-out
 		expected := sums[i]
+
 		if actual != expected {
 			t.Errorf("%d != %d", actual, expected)
 		}

--- a/components_for_test.go
+++ b/components_for_test.go
@@ -118,6 +118,7 @@ func (c *repeater) repeat(word string, times int) {
 	if word == "" || times <= 0 {
 		return
 	}
+
 	for i := 0; i < times; i++ {
 		c.Words <- word
 	}
@@ -133,18 +134,23 @@ type router struct {
 // outport key as the inport key they arrived at
 func (c *router) Process() {
 	wg := new(sync.WaitGroup)
+
 	for k, ch := range c.In {
 		k := k
 		ch := ch
+
 		wg.Add(1)
+
 		go func() {
 			for n := range ch {
 				c.Out[k] <- n
 			}
+
 			close(c.Out[k])
 			wg.Done()
 		}()
 	}
+
 	wg.Wait()
 }
 
@@ -158,18 +164,23 @@ type irouter struct {
 // outport key as the inport key they arrived at
 func (c *irouter) Process() {
 	wg := new(sync.WaitGroup)
+
 	for k, ch := range c.In {
 		k := k
 		ch := ch
+
 		wg.Add(1)
+
 		go func() {
 			for n := range ch {
 				c.Out[k] <- n
 			}
+
 			close(c.Out[k])
 			wg.Done()
 		}()
 	}
+
 	wg.Wait()
 }
 
@@ -202,5 +213,6 @@ func RegisterTestComponents(f *Factory) error {
 		Description: "Sums integers coming to its inports",
 		Icon:        "plus-circle",
 	})
+
 	return nil
 }

--- a/factory.go
+++ b/factory.go
@@ -56,12 +56,14 @@ func (f *Factory) Register(componentName string, constructor Constructor) error 
 	if _, exists := f.registry[componentName]; exists {
 		return fmt.Errorf("Registry error: component '%s' already registered", componentName)
 	}
+
 	f.registry[componentName] = registryEntry{
 		Constructor: constructor,
 		Info: ComponentInfo{
 			Name: componentName,
 		},
 	}
+
 	return nil
 }
 
@@ -70,10 +72,12 @@ func (f *Factory) Annotate(componentName string, annotation Annotation) error {
 	if _, exists := f.registry[componentName]; !exists {
 		return fmt.Errorf("Registry annotation error: component '%s' is not registered", componentName)
 	}
+
 	entry := f.registry[componentName]
 	entry.Info.Description = annotation.Description
 	entry.Info.Icon = annotation.Icon
 	f.registry[componentName] = entry
+
 	return nil
 }
 
@@ -84,6 +88,7 @@ func (f *Factory) Unregister(componentName string) error {
 		delete(f.registry, componentName)
 		return nil
 	}
+
 	return fmt.Errorf("Registry error: component '%s' is not registered", componentName)
 }
 
@@ -92,6 +97,7 @@ func (f *Factory) Create(componentName string) (interface{}, error) {
 	if info, exists := f.registry[componentName]; exists {
 		return info.Constructor()
 	}
+
 	return nil, fmt.Errorf("Factory error: component '%s' does not exist", componentName)
 }
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -7,6 +7,7 @@ import (
 func TestFactoryCreate(t *testing.T) {
 	f := NewFactory()
 	err := RegisterTestComponents(f)
+
 	if err != nil {
 		t.Error(err)
 		return
@@ -17,7 +18,9 @@ func TestFactoryCreate(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	c, ok := instance.(Component)
+
 	if !ok {
 		t.Errorf("%+v is not a Component", c)
 		return
@@ -68,34 +71,35 @@ func TestFactoryRegistration(t *testing.T) {
 
 func TestFactoryGraph(t *testing.T) {
 	f := NewFactory()
-	err := RegisterTestComponents(f)
-	if err != nil {
+
+	if err := RegisterTestComponents(f); err != nil {
 		t.Error(err)
 		return
 	}
-	err = RegisterTestGraph(f)
-	if err != nil {
+
+	if err := RegisterTestGraph(f); err != nil {
 		t.Error(err)
 		return
 	}
 
 	n := NewGraph()
 
-	if err = n.AddNew("de", "doubleEcho", f); err != nil {
-		t.Error(err)
-		return
-	}
-	if err = n.AddNew("e", "echo", f); err != nil {
+	if err := n.AddNew("de", "doubleEcho", f); err != nil {
 		t.Error(err)
 		return
 	}
 
-	if err = n.AddNew("notfound", "notfound", f); err == nil {
+	if err := n.AddNew("e", "echo", f); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := n.AddNew("notfound", "notfound", f); err == nil {
 		t.Errorf("Expected an error")
 		return
 	}
 
-	if err = n.Connect("de", "Out", "e", "In"); err != nil {
+	if err := n.Connect("de", "Out", "e", "In"); err != nil {
 		t.Error(err)
 		return
 	}

--- a/graph.go
+++ b/graph.go
@@ -81,11 +81,13 @@ func (n *Graph) Add(name string, c interface{}) error {
 	// c should be either graph or a component
 	_, isComponent := c.(Component)
 	_, isGraph := c.(Graph)
+
 	if !isComponent && !isGraph {
 		return fmt.Errorf("Could not add process '%s': instance is neither Component nor Graph", name)
 	}
 	// Add to the map of processes
 	n.procs[name] = c
+
 	return nil
 }
 
@@ -101,6 +103,7 @@ func (n *Graph) AddNew(processName string, componentName string, f *Factory) err
 	if err != nil {
 		return err
 	}
+
 	return n.Add(processName, proc)
 }
 
@@ -111,7 +114,9 @@ func (n *Graph) Remove(processName string) error {
 	if _, exists := n.procs[processName]; !exists {
 		return fmt.Errorf("Could not remove process: '%s' does not exist", processName)
 	}
+
 	delete(n.procs, processName)
+
 	return nil
 }
 
@@ -173,20 +178,25 @@ func (n *Graph) Process() {
 		// TODO provide a nicer way to handle graph errors
 		panic(err)
 	}
+
 	for _, i := range n.procs {
 		c, ok := i.(Component)
 		if !ok {
 			continue
 		}
+
 		n.waitGrp.Add(1)
+
 		w := Run(c)
 		proc := i
+
 		go func() {
 			<-w
 			n.closeProcOuts(proc)
 			n.waitGrp.Done()
 		}()
 	}
+
 	n.waitGrp.Wait()
 }
 
@@ -195,10 +205,12 @@ func (n *Graph) closeProcOuts(proc interface{}) {
 	for i := 0; i < val.NumField(); i++ {
 		field := val.Field(i)
 		fieldType := field.Type()
+
 		if !(field.IsValid() && field.Kind() == reflect.Chan && field.CanSet() &&
 			fieldType.ChanDir()&reflect.SendDir != 0 && fieldType.ChanDir()&reflect.RecvDir == 0) {
 			continue
 		}
+
 		if n.decChanListenersCount(field) {
 			field.Close()
 		}

--- a/graph_connect.go
+++ b/graph_connect.go
@@ -19,6 +19,7 @@ func (a address) String() string {
 	if a.key != "" {
 		return fmt.Sprintf("%s.%s[%s]", a.proc, a.port, a.key)
 	}
+
 	return fmt.Sprintf("%s.%s", a.proc, a.port)
 }
 
@@ -42,12 +43,14 @@ func (n *Graph) Connect(senderName, senderPort, receiverName, receiverPort strin
 // It returns true on success or panics and returns false if error occurs.
 func (n *Graph) ConnectBuf(senderName, senderPort, receiverName, receiverPort string, bufferSize int) error {
 	sendAddr := parseAddress(senderName, senderPort)
+
 	sendPort, err := n.getProcPort(senderName, sendAddr.port, reflect.SendDir)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
 
 	recvAddr := parseAddress(receiverName, receiverPort)
+
 	recvPort, err := n.getProcPort(receiverName, recvAddr.port, reflect.RecvDir)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
@@ -68,14 +71,15 @@ func (n *Graph) ConnectBuf(senderName, senderPort, receiverName, receiverPort st
 			isNewChan = true
 		}
 	}
-	ch, err = attachPort(sendPort, sendAddr, reflect.SendDir, ch, bufferSize)
-	if err != nil {
+
+	if ch, err = attachPort(sendPort, sendAddr, reflect.SendDir, ch, bufferSize); err != nil {
 		return fmt.Errorf("connect '%s.%s': %w", senderName, senderPort, err)
 	}
 
 	if _, err = attachPort(recvPort, recvAddr, reflect.RecvDir, ch, bufferSize); err != nil {
 		return fmt.Errorf("connect '%s.%s': %w", receiverName, receiverPort, err)
 	}
+
 	if isNewChan {
 		// Register the first listener on a newly created channel
 		n.incChanListenersCount(ch)
@@ -105,13 +109,17 @@ func (n *Graph) getProcPort(procName, portName string, dir reflect.ChanDir) (ref
 	if val.Kind() == reflect.Ptr && val.IsValid() {
 		val = val.Elem()
 	}
+
 	if !val.CanSet() {
 		return nilValue, fmt.Errorf("getProcPort: process '%s' is not settable", procName)
 	}
 
 	// Get the port value
-	var portVal reflect.Value
-	var err error
+	var (
+		portVal reflect.Value
+		err     error
+	)
+
 	// Check if sender is a net
 	net, ok := val.Interface().(Graph)
 	if ok {
@@ -133,9 +141,11 @@ func (n *Graph) getProcPort(procName, portName string, dir reflect.ChanDir) (ref
 		// Sender is a proc
 		portVal = val.FieldByName(portName)
 	}
+
 	if err == nil && (!portVal.IsValid()) {
 		err = fmt.Errorf("process '%s' does not have a valid port '%s'", procName, portName)
 	}
+
 	if err != nil {
 		return nilValue, fmt.Errorf("getProcPort: %w", err)
 	}
@@ -147,9 +157,11 @@ func attachPort(port reflect.Value, addr address, dir reflect.ChanDir, ch reflec
 	if addr.index > -1 {
 		return attachArrayPort(port, addr.index, dir, ch, bufSize)
 	}
+
 	if addr.key != "" {
 		return attachMapPort(port, addr.key, dir, ch, bufSize)
 	}
+
 	return attachChanPort(port, dir, ch, bufSize)
 }
 
@@ -157,11 +169,14 @@ func attachChanPort(port reflect.Value, dir reflect.ChanDir, ch reflect.Value, b
 	if err := validateChanDir(port.Type(), dir); err != nil {
 		return ch, err
 	}
+
 	if err := validateCanSet(port); err != nil {
 		return ch, err
 	}
+
 	ch = selectOrMakeChan(ch, port, port.Type().Elem(), bufSize)
 	port.Set(ch)
+
 	return ch, nil
 }
 
@@ -169,14 +184,18 @@ func attachMapPort(port reflect.Value, key string, dir reflect.ChanDir, ch refle
 	if err := validateChanDir(port.Type().Elem(), dir); err != nil {
 		return ch, err
 	}
+
 	kv := reflect.ValueOf(key)
 	item := port.MapIndex(kv)
 	ch = selectOrMakeChan(ch, item, port.Type().Elem().Elem(), bufSize)
+
 	if port.IsNil() {
 		m := reflect.MakeMap(port.Type())
 		port.Set(m)
 	}
+
 	port.SetMapIndex(kv, ch)
+
 	return ch, nil
 }
 
@@ -184,19 +203,24 @@ func attachArrayPort(port reflect.Value, key int, dir reflect.ChanDir, ch reflec
 	if err := validateChanDir(port.Type().Elem(), dir); err != nil {
 		return ch, err
 	}
+
 	if port.IsNil() {
 		m := reflect.MakeSlice(port.Type(), 0, 32)
 		port.Set(m)
 	}
+
 	if port.Cap() <= key {
 		port.SetCap(2 * key)
 	}
+
 	if port.Len() <= key {
 		port.SetLen(key + 1)
 	}
+
 	item := port.Index(key)
 	ch = selectOrMakeChan(ch, item, port.Type().Elem().Elem(), bufSize)
 	item.Set(ch)
+
 	return ch, nil
 }
 
@@ -208,6 +232,7 @@ func validateChanDir(portType reflect.Type, dir reflect.ChanDir) error {
 	if portType.ChanDir()&dir == 0 {
 		return fmt.Errorf("channel does not support direction %s", dir.String())
 	}
+
 	return nil
 }
 
@@ -215,6 +240,7 @@ func validateCanSet(portVal reflect.Value) error {
 	if !portVal.CanSet() {
 		return fmt.Errorf("port is not assignable")
 	}
+
 	return nil
 }
 
@@ -223,9 +249,11 @@ func selectOrMakeChan(new, existing reflect.Value, t reflect.Type, bufSize int) 
 		if existing.IsValid() && !existing.IsNil() {
 			return existing
 		}
+
 		chanType := reflect.ChanOf(reflect.BothDir, t)
 		new = reflect.MakeChan(chanType, bufSize)
 	}
+
 	return new
 }
 
@@ -238,25 +266,32 @@ func parseAddress(proc, port string) address {
 	}
 	keyPos := 0
 	key := ""
+
 	for i, r := range port {
 		if r == '[' {
 			keyPos = i + 1
 			n.port = port[0:i]
 		}
+
 		if r == ']' {
 			key = port[keyPos:i]
 		}
 	}
+
 	n.port = capitalizePortName(n.port)
+
 	if key == "" {
 		return n
 	}
+
 	if i, err := strconv.Atoi(key); err == nil {
 		n.index = i
 	} else {
 		n.key = key
 	}
+
 	n.key = key
+
 	return n
 }
 
@@ -265,9 +300,11 @@ func parseAddress(proc, port string) address {
 func capitalizePortName(name string) string {
 	lower := strings.ToLower(name)
 	upper := strings.ToUpper(name)
+
 	if name == lower || name == upper {
 		return strings.Title(lower)
 	}
+
 	return name
 }
 
@@ -282,11 +319,13 @@ func (n *Graph) findExistingChan(addr address, dir reflect.ChanDir) reflect.Valu
 		} else {
 			a = n.connections[i].tgt
 		}
+
 		if a == addr {
 			channel = n.connections[i].channel
 			break
 		}
 	}
+
 	return channel
 }
 
@@ -313,11 +352,14 @@ func (n *Graph) decChanListenersCount(c reflect.Value) bool {
 
 	ptr := c.Pointer()
 	cnt := n.chanListenersCount[ptr]
+
 	if cnt == 0 {
 		return true // yes you may try to close a nonexistant channel, see what happens...
 	}
+
 	cnt--
 	n.chanListenersCount[ptr] = cnt
+
 	return cnt == 0
 }
 

--- a/graph_connect_test.go
+++ b/graph_connect_test.go
@@ -118,6 +118,7 @@ func TestSubgraphSender(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	n.Add("e3", new(echo))
 
 	if err := n.Connect("sub", "Out", "e3", "In"); err != nil {
@@ -143,6 +144,7 @@ func TestSubgraphReceiver(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	n.Add("e3", new(echo))
 
 	if err := n.Connect("e3", "Out", "sub", "In"); err != nil {
@@ -206,6 +208,7 @@ func TestFanOutFanIn(t *testing.T) {
 
 	in := make(chan int)
 	out := make(chan int)
+
 	n.SetInPort("In", in)
 	n.SetOutPort("Out", out)
 
@@ -215,18 +218,23 @@ func TestFanOutFanIn(t *testing.T) {
 		for _, n := range inData {
 			in <- n
 		}
+
 		close(in)
 	}()
 
 	i := 0
+
 	for actual := range out {
 		found := false
+
 		for j := 0; j < len(outData); j++ {
 			if outData[j] == actual {
 				found = true
+
 				outData = append(outData[:j], outData[j+1:]...)
 			}
 		}
+
 		if !found {
 			t.Errorf("%d not found in expected data", actual)
 		}
@@ -308,12 +316,15 @@ func TestMapPorts(t *testing.T) {
 	o1 := make(chan int)
 	o2 := make(chan int)
 	o3 := make(chan int)
+
 	if err := n.SetInPort("I2", i2); err != nil {
 		t.Error(err)
 		return
 	}
+
 	n.SetOutPort("O1", o1)
 	n.SetOutPort("O2", o2)
+
 	if err := n.SetOutPort("O3", o3); err != nil {
 		t.Error(err)
 		return
@@ -323,6 +334,7 @@ func TestMapPorts(t *testing.T) {
 
 	i2 <- 2
 	close(i2)
+
 	v1 := <-o1
 	v2 := <-o2
 	v3 := <-o3
@@ -407,12 +419,15 @@ func TestArrayPorts(t *testing.T) {
 	o0 := make(chan int)
 	o1 := make(chan int)
 	o2 := make(chan int)
+
 	if err := n.SetInPort("I1", i1); err != nil {
 		t.Error(err)
 		return
 	}
+
 	n.SetOutPort("O0", o0)
 	n.SetOutPort("O1", o1)
+
 	if err := n.SetOutPort("O2", o2); err != nil {
 		t.Error(err)
 		return
@@ -422,6 +437,7 @@ func TestArrayPorts(t *testing.T) {
 
 	i1 <- 2
 	close(i1)
+
 	v0 := <-o0
 	v1 := <-o1
 	v2 := <-o2

--- a/graph_iip_test.go
+++ b/graph_iip_test.go
@@ -25,6 +25,7 @@ func TestBasicIIP(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	if err := n.AddIIP("r", "Times", qty); err != nil {
 		t.Error(err)
 		return
@@ -40,6 +41,7 @@ func TestBasicIIP(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	if err := n.SetOutPort("Words", out); err != nil {
 		t.Error(err)
 		return
@@ -53,6 +55,7 @@ func TestBasicIIP(t *testing.T) {
 	}()
 
 	i := 0
+
 	for actual := range out {
 		expected := output[i]
 		if actual != expected {
@@ -60,6 +63,7 @@ func TestBasicIIP(t *testing.T) {
 		}
 		i++
 	}
+
 	if i != qty {
 		t.Errorf("Returned %d words instead of %d", i, qty)
 	}
@@ -82,8 +86,6 @@ func newRepeatGraph2Ins() (*Graph, error) {
 }
 
 func TestGraphInportIIP(t *testing.T) {
-	qty := 5
-
 	n, err := newRepeatGraph2Ins()
 	if err != nil {
 		t.Error(err)
@@ -92,6 +94,7 @@ func TestGraphInportIIP(t *testing.T) {
 
 	input := "hello"
 	output := []string{"hello", "hello", "hello", "hello", "hello"}
+	qty := len(output)
 
 	in := make(chan string)
 	times := make(chan int)
@@ -101,14 +104,17 @@ func TestGraphInportIIP(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	if err := n.SetInPort("Times", times); err != nil {
 		t.Error(err)
 		return
 	}
+
 	if err := n.SetOutPort("Words", out); err != nil {
 		t.Error(err)
 		return
 	}
+
 	if err := n.AddIIP("r", "Times", qty); err != nil {
 		t.Error(err)
 		return
@@ -127,12 +133,13 @@ func TestGraphInportIIP(t *testing.T) {
 			// The graph inport needs to be closed once the IIP is sent
 			close(times)
 		}
-		expected := output[i]
-		if actual != expected {
+
+		if expected := output[i]; actual != expected {
 			t.Errorf("%s != %s", actual, expected)
 		}
 		i++
 	}
+
 	if i != qty {
 		t.Errorf("Returned %d words instead of %d", i, qty)
 	}
@@ -164,6 +171,7 @@ func TestInternalConnectionIIP(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	if err := n.SetOutPort("Out", out); err != nil {
 		t.Error(err)
 		return
@@ -177,6 +185,7 @@ func TestInternalConnectionIIP(t *testing.T) {
 	}()
 
 	i := 0
+
 	for actual := range out {
 		// The order of output is not guaranteed in this case
 		if actual != output[0] && actual != output[1] {
@@ -184,6 +193,7 @@ func TestInternalConnectionIIP(t *testing.T) {
 		}
 		i++
 	}
+
 	if i != qty {
 		t.Errorf("Returned %d words instead of %d", i, qty)
 	}

--- a/graph_ports.go
+++ b/graph_ports.go
@@ -79,8 +79,11 @@ func (n *Graph) SetOutPort(name string, channel interface{}) error {
 }
 
 func (n *Graph) setGraphPort(name string, channel interface{}, dir reflect.ChanDir) error {
-	var ports map[string]port
-	var dirDescr string
+	var (
+		ports    map[string]port
+		dirDescr string
+	)
+
 	if dir == reflect.SendDir {
 		ports = n.outPorts
 		dirDescr = "out"
@@ -88,22 +91,26 @@ func (n *Graph) setGraphPort(name string, channel interface{}, dir reflect.ChanD
 		ports = n.inPorts
 		dirDescr = "in"
 	}
+
 	p, ok := ports[name]
 	if !ok {
 		return fmt.Errorf("setGraphPort: %s port '%s' not defined", dirDescr, name)
 	}
+
 	// Try to attach it
 	port, err := n.getProcPort(p.addr.proc, p.addr.port, dir)
 	if err != nil {
 		return fmt.Errorf("setGraphPort: cannot set %s port '%s': %w", dirDescr, name, err)
 	}
-	_, err = attachPort(port, p.addr, dir, reflect.ValueOf(channel), n.conf.BufferSize)
-	if err != nil {
+
+	if _, err = attachPort(port, p.addr, dir, reflect.ValueOf(channel), n.conf.BufferSize); err != nil {
 		return fmt.Errorf("setGraphPort: cannot attach %s port '%s': %w", dirDescr, name, err)
 	}
+
 	// Save it in inPorts to be used with IIPs if needed
 	p.channel = reflect.ValueOf(channel)
 	ports[name] = p
+
 	return nil
 }
 

--- a/graph_ports_test.go
+++ b/graph_ports_test.go
@@ -14,6 +14,7 @@ func TestOutportNotFound(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	n.Add("e3", new(echo))
 
 	if err := n.Connect("sub", "NoOut", "e3", "In"); err == nil {
@@ -33,6 +34,7 @@ func TestInPortNotFound(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
 	n.Add("e3", new(echo))
 
 	if err := n.Connect("e3", "Out", "sub", "NotIn"); err == nil {

--- a/graph_test.go
+++ b/graph_test.go
@@ -9,19 +9,24 @@ func newDoubleEcho() (*Graph, error) {
 	// Components
 	e1 := new(echo)
 	e2 := new(echo)
+
 	// Structure
 	if err := n.Add("e1", e1); err != nil {
 		return nil, err
 	}
+
 	if err := n.Add("e2", e2); err != nil {
 		return nil, err
 	}
+
 	if err := n.Connect("e1", "Out", "e2", "In"); err != nil {
 		return nil, err
 	}
+
 	// Ports
 	n.MapInPort("In", "e1", "In")
 	n.MapOutPort("Out", "e2", "Out")
+
 	return n, nil
 }
 
@@ -40,6 +45,7 @@ func testGraphWithNumberSequence(n *Graph, t *testing.T) {
 
 	in := make(chan int)
 	out := make(chan int)
+
 	n.SetInPort("In", in)
 	n.SetOutPort("Out", out)
 
@@ -49,10 +55,12 @@ func testGraphWithNumberSequence(n *Graph, t *testing.T) {
 		for _, n := range data {
 			in <- n
 		}
+
 		close(in)
 	}()
 
 	i := 0
+
 	for actual := range out {
 		expected := data[i]
 		if actual != expected {
@@ -68,6 +76,7 @@ func TestAddInvalidProcess(t *testing.T) {
 	s := struct{ Name string }{"This is not a Component"}
 	n := NewGraph()
 	err := n.Add("wrong", s)
+
 	if err == nil {
 		t.Errorf("Expected an error")
 	}
@@ -76,14 +85,17 @@ func TestAddInvalidProcess(t *testing.T) {
 func TestRemove(t *testing.T) {
 	n := NewGraph()
 	e1 := new(echo)
+
 	if err := n.Add("e1", e1); err != nil {
 		t.Error(err)
 		return
 	}
+
 	if err := n.Remove("e1"); err != nil {
 		t.Error(err)
 		return
 	}
+
 	if err := n.Remove("e2"); err == nil {
 		t.Errorf("Expected an error")
 		return
@@ -94,8 +106,10 @@ func RegisterTestGraph(f *Factory) error {
 	f.Register("doubleEcho", func() (interface{}, error) {
 		return newDoubleEcho()
 	})
+
 	f.Annotate("doubleEcho", Annotation{
 		Description: "Contains a chain of two echo components",
 	})
+
 	return nil
 }


### PR DESCRIPTION
After enabling `wsl` and making it happy, `funlen` started complaining about the `sendIIPs()` length, so I refactored a couple pieces into separate functions.