### PR TITLE
Remove InputGuard, refactor test components without it

### DIFF
--- a/component.go
+++ b/component.go
@@ -22,29 +22,3 @@ func Run(c Component) Wait {
 
 	return wait
 }
-
-// InputGuard counts number of closed inputs
-type InputGuard struct {
-	ports    map[string]bool
-	complete int
-}
-
-// NewInputGuard returns a guard for a given number of inputs
-func NewInputGuard(ports ...string) *InputGuard {
-	portMap := make(map[string]bool, len(ports))
-	for _, p := range ports {
-		portMap[p] = false
-	}
-
-	return &InputGuard{portMap, 0}
-}
-
-// Complete is called when a port is closed and returns true when all the ports have been closed
-func (g *InputGuard) Complete(port string) bool {
-	if !g.ports[port] {
-		g.ports[port] = true
-		g.complete++
-	}
-
-	return g.complete >= len(g.ports)
-}


### PR DESCRIPTION
**Rationale**: `InputGuard` is unsafe to use; components for test provide a bad example.
**Explanation**: The key problem is that [after a channel is closed, it never blocks reads](https://dave.cheney.net/2014/03/19/channel-axioms). The existing implementation leads to a dead `select` loop, which eventually exits when `select` randomly chooses another execution branch. Updated component implementations provide a more accurate example of handling closed channels in go.
Additionally, keeping a map of inputs is expensive and totally unnecessary, as it can be seen from the updated impl.
Finally, if we were to preserve `InputGuard`-s for some reason, the implementation would have to be changed for safety. Consider what would happen if you accidentally `Complete()`-d a non-existing port. What would happen if you accidentally `Complete()`-d the same port twice?