### PR TITLE
Enable godot, drop Capacity from the GraphConfig

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -348,6 +348,7 @@ linters:
     - megacheck
     - govet
     - gocritic
+    - godot
     - gofumpt
     - gosec
     - golint
@@ -391,7 +392,6 @@ linters:
     - dupl
     - gocognit
     - gocyclo
-    - godot
     - godox
     - goerr113
     - gomnd

--- a/component.go
+++ b/component.go
@@ -1,17 +1,17 @@
 package goflow
 
-// Component is a unit that can start a process
+// Component is a unit that can start a process.
 type Component interface {
 	Process()
 }
 
-// Done notifies that the process is finished
+// Done notifies that the process is finished.
 type Done struct{}
 
-// Wait is a channel signaling of a completion
-type Wait chan struct{}
+// Wait is a channel signaling of a completion.
+type Wait chan Done
 
-// Run the component process
+// Run the component process.
 func Run(c Component) Wait {
 	wait := make(Wait)
 

--- a/component_test.go
+++ b/component_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-// Test a simple component that runs only once
+// Test a simple component that runs only once.
 func TestSimpleComponent(t *testing.T) {
 	in := make(chan int)
 	out := make(chan int)
@@ -26,7 +26,7 @@ func TestSimpleComponent(t *testing.T) {
 	<-wait
 }
 
-// Test a simple long running component with one input
+// Test a simple long running component with one input.
 func TestSimpleLongRunningComponent(t *testing.T) {
 	data := map[int]int{
 		12:  24,

--- a/components_for_test.go
+++ b/components_for_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// doubler doubles its input
+// doubler doubles its input.
 type doubler struct {
 	In  <-chan int
 	Out chan<- int
@@ -16,7 +16,7 @@ func (c *doubler) Process() {
 	}
 }
 
-// doubleOnce is a non-resident version of doubler
+// doubleOnce is a non-resident version of doubler.
 type doubleOnce struct {
 	In  <-chan int
 	Out chan<- int
@@ -27,7 +27,7 @@ func (c *doubleOnce) Process() {
 	c.Out <- 2 * i
 }
 
-// A component with two inputs and one output
+// A component with two inputs and one output.
 type adder struct {
 	Op1 <-chan int
 	Op2 <-chan int
@@ -67,7 +67,7 @@ func (c *adder) Process() {
 	}
 }
 
-// echo passes input to the output
+// echo passes input to the output.
 type echo struct {
 	In  <-chan int
 	Out chan<- int
@@ -79,7 +79,7 @@ func (c *echo) Process() {
 	}
 }
 
-// repeater repeats an input string a given number of times
+// repeater repeats an input string a given number of times.
 type repeater struct {
 	Word  <-chan string
 	Times <-chan int
@@ -123,14 +123,14 @@ func (c *repeater) repeat(word string, times int) {
 	}
 }
 
-// router routes input map port to output
+// router routes input map port to output.
 type router struct {
 	In  map[string]<-chan int
 	Out map[string]chan<- int
 }
 
 // Process routes incoming packets to the output by sending them to the same
-// outport key as the inport key they arrived at
+// outport key as the inport key they arrived at.
 func (c *router) Process() {
 	wg := new(sync.WaitGroup)
 
@@ -153,14 +153,14 @@ func (c *router) Process() {
 	wg.Wait()
 }
 
-// irouter routes input array port to output
+// irouter routes input array port to output.
 type irouter struct {
 	In  [](<-chan int)
 	Out [](chan<- int)
 }
 
 // Process routes incoming packets to the output by sending them to the same
-// outport key as the inport key they arrived at
+// outport key as the inport key they arrived at.
 func (c *irouter) Process() {
 	wg := new(sync.WaitGroup)
 

--- a/factory.go
+++ b/factory.go
@@ -2,11 +2,10 @@ package goflow
 
 import "fmt"
 
-// Constructor is used to create a component instance at run-time
+// Constructor is used to create a component instance at run-time.
 type Constructor func() (interface{}, error)
 
-// Annotation provides reference information about a component
-// to graph designers and operators
+// Annotation provides reference information about a component to graph designers and operators.
 type Annotation struct {
 	// Description tells what the component does
 	Description string
@@ -14,7 +13,7 @@ type Annotation struct {
 	Icon string
 }
 
-// registryEntry contains runtime information about a component
+// registryEntry contains runtime information about a component.
 type registryEntry struct {
 	// Constructor is a function that creates a component instance.
 	// It is required for the factory to add components at run-time.
@@ -23,7 +22,7 @@ type registryEntry struct {
 	Info ComponentInfo
 }
 
-// FactoryConfig sets up properties of a Factory
+// FactoryConfig sets up properties of a Factory.
 type FactoryConfig struct {
 	RegistryCapacity uint
 }
@@ -34,12 +33,12 @@ func defaultFactoryConfig() FactoryConfig {
 	}
 }
 
-// Factory registers components and creates their instances at run-time
+// Factory registers components and creates their instances at run-time.
 type Factory struct {
 	registry map[string]registryEntry
 }
 
-// NewFactory creates a new component Factory instance
+// NewFactory creates a new component Factory instance.
 func NewFactory(config ...FactoryConfig) *Factory {
 	conf := defaultFactoryConfig()
 	if len(config) == 1 {
@@ -51,7 +50,7 @@ func NewFactory(config ...FactoryConfig) *Factory {
 	}
 }
 
-// Register registers a component so that it can be instantiated at run-time
+// Register registers a component so that it can be instantiated at run-time.
 func (f *Factory) Register(componentName string, constructor Constructor) error {
 	if _, exists := f.registry[componentName]; exists {
 		return fmt.Errorf("registry error: component '%s' already registered", componentName)
@@ -67,7 +66,7 @@ func (f *Factory) Register(componentName string, constructor Constructor) error 
 	return nil
 }
 
-// Annotate adds human-readable documentation for a component to the runtime
+// Annotate adds human-readable documentation for a component to the runtime.
 func (f *Factory) Annotate(componentName string, annotation Annotation) error {
 	if _, exists := f.registry[componentName]; !exists {
 		return fmt.Errorf("registry annotation error: component '%s' is not registered", componentName)

--- a/factory.go
+++ b/factory.go
@@ -2,51 +2,25 @@ package goflow
 
 import "fmt"
 
-// Constructor is used to create a component instance at run-time.
-type Constructor func() (interface{}, error)
-
-// Annotation provides reference information about a component to graph designers and operators.
-type Annotation struct {
-	// Description tells what the component does
-	Description string
-	// Icon name in Font Awesome is used for visualization
-	Icon string
+// Factory registers components and creates their instances at run-time.
+// Not safe for concurrent use.
+type Factory struct {
+	registry map[string]registryEntry // map by the component name
 }
 
 // registryEntry contains runtime information about a component.
 type registryEntry struct {
-	// Constructor is a function that creates a component instance.
-	// It is required for the factory to add components at run-time.
-	Constructor Constructor
-	// Run-time component description
-	Info ComponentInfo
+	constructor Constructor   // Function for creating component instances at run-time
+	info        ComponentInfo // Run-time component description
 }
 
-// FactoryConfig sets up properties of a Factory.
-type FactoryConfig struct {
-	RegistryCapacity uint
-}
-
-func defaultFactoryConfig() FactoryConfig {
-	return FactoryConfig{
-		RegistryCapacity: 64,
-	}
-}
-
-// Factory registers components and creates their instances at run-time.
-type Factory struct {
-	registry map[string]registryEntry
-}
+// Constructor is used to create a component instance at run-time.
+type Constructor func() (interface{}, error)
 
 // NewFactory creates a new component Factory instance.
-func NewFactory(config ...FactoryConfig) *Factory {
-	conf := defaultFactoryConfig()
-	if len(config) == 1 {
-		conf = config[0]
-	}
-
+func NewFactory() *Factory {
 	return &Factory{
-		registry: make(map[string]registryEntry, conf.RegistryCapacity),
+		registry: make(map[string]registryEntry),
 	}
 }
 
@@ -57,8 +31,8 @@ func (f *Factory) Register(componentName string, constructor Constructor) error 
 	}
 
 	f.registry[componentName] = registryEntry{
-		Constructor: constructor,
-		Info: ComponentInfo{
+		constructor: constructor,
+		info: ComponentInfo{
 			Name: componentName,
 		},
 	}
@@ -66,15 +40,21 @@ func (f *Factory) Register(componentName string, constructor Constructor) error 
 	return nil
 }
 
+// Annotation provides reference information about a component to graph designers and operators.
+type Annotation struct {
+	Description string // Description of what the component does
+	Icon        string // Icon name in Font Awesome used for visualization
+}
+
 // Annotate adds human-readable documentation for a component to the runtime.
 func (f *Factory) Annotate(componentName string, annotation Annotation) error {
-	if _, exists := f.registry[componentName]; !exists {
+	entry, exists := f.registry[componentName]
+	if !exists {
 		return fmt.Errorf("registry annotation error: component '%s' is not registered", componentName)
 	}
 
-	entry := f.registry[componentName]
-	entry.Info.Description = annotation.Description
-	entry.Info.Icon = annotation.Icon
+	entry.info.Description = annotation.Description
+	entry.info.Icon = annotation.Icon
 	f.registry[componentName] = entry
 
 	return nil
@@ -83,21 +63,23 @@ func (f *Factory) Annotate(componentName string, annotation Annotation) error {
 // Unregister removes a component with a given name from the component registry and returns true
 // or returns false if no such component is registered.
 func (f *Factory) Unregister(componentName string) error {
-	if _, exists := f.registry[componentName]; exists {
-		delete(f.registry, componentName)
-		return nil
+	if _, exists := f.registry[componentName]; !exists {
+		return fmt.Errorf("registry error: component '%s' is not registered", componentName)
 	}
 
-	return fmt.Errorf("registry error: component '%s' is not registered", componentName)
+	delete(f.registry, componentName)
+
+	return nil
 }
 
 // Create creates a new instance of a component registered under a specific name.
 func (f *Factory) Create(componentName string) (interface{}, error) {
-	if info, exists := f.registry[componentName]; exists {
-		return info.Constructor()
+	info, exists := f.registry[componentName]
+	if !exists {
+		return nil, fmt.Errorf("factory error: component '%s' does not exist", componentName)
 	}
 
-	return nil, fmt.Errorf("factory error: component '%s' does not exist", componentName)
+	return info.constructor()
 }
 
 // // UpdateComponentInfo extracts run-time information about a

--- a/factory_test.go
+++ b/factory_test.go
@@ -32,9 +32,7 @@ func TestFactoryCreate(t *testing.T) {
 }
 
 func TestFactoryRegistration(t *testing.T) {
-	f := NewFactory(FactoryConfig{
-		RegistryCapacity: 10,
-	})
+	f := NewFactory()
 
 	if err := RegisterTestComponents(f); err != nil {
 		t.Error(err)

--- a/graph_connect.go
+++ b/graph_connect.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 )
 
-// address is a full port accessor including the index part
+// address is a full port accessor including the index part.
 type address struct {
-	proc  string
-	port  string
-	key   string
-	index int
+	proc  string // Process name
+	port  string // Component port name
+	key   string // Port key (only for map ports)
+	index int    // Port index (only for array ports)
 }
 
 func (a address) String() string {
@@ -96,7 +96,7 @@ func (n *Graph) ConnectBuf(senderName, senderPort, receiverName, receiverPort st
 	return nil
 }
 
-// getProcPort finds an assignable port field in one of the subprocesses
+// getProcPort finds an assignable port field in one of the subprocesses.
 func (n *Graph) getProcPort(procName, portName string, dir reflect.ChanDir) (reflect.Value, error) {
 	nilValue := reflect.ValueOf(nil)
 	// Check if process exists
@@ -258,7 +258,7 @@ func selectOrMakeChan(new, existing reflect.Value, t reflect.Type, bufSize int) 
 	return new
 }
 
-// parseAddress unfolds a string port name into parts, including array index or hashmap key
+// parseAddress unfolds a string port name into parts, including array index or hashmap key.
 func parseAddress(proc, port string) address {
 	n := address{
 		proc:  proc,
@@ -296,8 +296,8 @@ func parseAddress(proc, port string) address {
 	return n
 }
 
-// capitalizePortName contains port names defined in UPPER or lower case to Title case,
-// which is more common for structs in Go
+// capitalizePortName converts port names defined in UPPER or lower case to Title case,
+// which is more common for structs in Go.
 func capitalizePortName(name string) string {
 	lower := strings.ToLower(name)
 	upper := strings.ToUpper(name)
@@ -309,7 +309,7 @@ func capitalizePortName(name string) string {
 	return name
 }
 
-// findExistingChan returns a channel attached to receiver if it already exists among connections
+// findExistingChan returns a channel attached to receiver if it already exists among connections.
 func (n *Graph) findExistingChan(addr address, dir reflect.ChanDir) reflect.Value {
 	var channel reflect.Value
 	// Find existing channel attached to the receiver
@@ -346,7 +346,7 @@ func (n *Graph) incChanListenersCount(c reflect.Value) {
 }
 
 // decChanListenersCount decrements SendChanRefCount
-// It returns true if the RefCount has reached 0
+// It returns true if the RefCount has reached 0.
 func (n *Graph) decChanListenersCount(c reflect.Value) bool {
 	n.chanListenersCountLock.Lock()
 	defer n.chanListenersCountLock.Unlock()
@@ -355,7 +355,7 @@ func (n *Graph) decChanListenersCount(c reflect.Value) bool {
 	cnt := n.chanListenersCount[ptr]
 
 	if cnt == 0 {
-		return true // yes you may try to close a nonexistant channel, see what happens...
+		return true // yes you may try to close a nonexistent channel, see what happens...
 	}
 
 	cnt--

--- a/graph_iip.go
+++ b/graph_iip.go
@@ -5,14 +5,14 @@ import (
 	"reflect"
 )
 
-// iip stands for Initial Information Packet representation
-// within the network.
+// iip is the Initial Information Packet.
+// IIPs are delivered to process input ports on the network start.
 type iip struct {
 	data interface{}
 	addr address
 }
 
-// AddIIP adds an Initial Information packet to the network
+// AddIIP adds an Initial Information packet to the network.
 func (n *Graph) AddIIP(processName, portName string, data interface{}) error {
 	addr := parseAddress(processName, portName)
 
@@ -24,7 +24,7 @@ func (n *Graph) AddIIP(processName, portName string, data interface{}) error {
 	return fmt.Errorf("AddIIP: could not find '%s'", addr)
 }
 
-// RemoveIIP detaches an IIP from specific process and port
+// RemoveIIP detaches an IIP from specific process and port.
 func (n *Graph) RemoveIIP(processName, portName string) error {
 	addr := parseAddress(processName, portName)
 	for i := range n.iips {
@@ -38,7 +38,7 @@ func (n *Graph) RemoveIIP(processName, portName string) error {
 	return fmt.Errorf("RemoveIIP: could not find IIP for '%s'", addr)
 }
 
-// sendIIPs sends Initial Information Packets upon network start
+// sendIIPs sends Initial Information Packets upon network start.
 func (n *Graph) sendIIPs() error {
 	// Send initial IPs
 	for i := range n.iips {
@@ -86,7 +86,7 @@ func (n *Graph) sendIIPs() error {
 	return nil
 }
 
-// channelByInPortAddr returns a channel by address from the network inports
+// channelByInPortAddr returns a channel by address from the network inports.
 func (n *Graph) channelByInPortAddr(addr address) (channel reflect.Value, found bool) {
 	for i := range n.inPorts {
 		if n.inPorts[i].addr == addr {
@@ -97,7 +97,7 @@ func (n *Graph) channelByInPortAddr(addr address) (channel reflect.Value, found 
 	return reflect.Value{}, false
 }
 
-// channelByConnectionAddr returns a channel by address from connections
+// channelByConnectionAddr returns a channel by address from connections.
 func (n *Graph) channelByConnectionAddr(addr address) (channel reflect.Value, found bool) {
 	for i := range n.connections {
 		if n.connections[i].tgt == addr {

--- a/graph_ports.go
+++ b/graph_ports.go
@@ -5,14 +5,11 @@ import (
 	"reflect"
 )
 
-// port stores full port information within the network.
+// port within the network.
 type port struct {
-	// Address of the port in the graph
-	addr address
-	// Actual channel attached
-	channel reflect.Value
-	// Runtime info
-	info PortInfo
+	addr    address       // Address of the port in the graph
+	channel reflect.Value // Actual channel attached
+	info    PortInfo      // Runtime info
 }
 
 // MapInPort adds an inport to the net and maps it to a contained proc's port.

--- a/protocol.go
+++ b/protocol.go
@@ -1,6 +1,6 @@
 package goflow
 
-// PortInfo represents a port to a runtime client
+// PortInfo represents a port to a runtime client.
 type PortInfo struct {
 	ID          string        `json:"id"`
 	Type        string        `json:"type"`
@@ -11,7 +11,7 @@ type PortInfo struct {
 	Default     interface{}   `json:"default"` // ignored
 }
 
-// ComponentInfo represents a component to a protocol client
+// ComponentInfo represents a component to a protocol client.
 type ComponentInfo struct {
 	Name        string     `json:"name"`
 	Description string     `json:"description"`
@@ -21,7 +21,7 @@ type ComponentInfo struct {
 	OutPorts    []PortInfo `json:"outPorts"`
 }
 
-// Message represents a single FBP protocol message
+// Message represents a single FBP protocol message.
 type Message struct {
 	// Protocol is NoFlo protocol identifier:
 	// "runtime", "component", "graph" or "network"
@@ -32,7 +32,7 @@ type Message struct {
 	Payload interface{} `json:"payload"`
 }
 
-// runtimeInfo message contains response to runtime.getruntime request
+// runtimeInfo message contains response to runtime.getruntime request.
 type runtimeInfo struct {
 	Type         string   `json:"type"`
 	Version      string   `json:"version"`
@@ -46,7 +46,7 @@ type runtimeMessage struct {
 	Payload  runtimeInfo `json:"payload"`
 }
 
-// clearGraph message is sent by client to create a new empty graph
+// clearGraph message is sent by client to create a new empty graph.
 type clearGraph struct {
 	ID          string
 	Name        string `json:",omitempty"` // ignored
@@ -56,7 +56,7 @@ type clearGraph struct {
 	Description string `json:",omitempty"`
 }
 
-// addNode message is sent by client to add a node to a graph
+// addNode message is sent by client to add a node to a graph.
 type addNode struct {
 	ID        string
 	Component string
@@ -64,28 +64,27 @@ type addNode struct {
 	Metadata  map[string]interface{} `json:",omitempty"` // ignored
 }
 
-// removeNode is a client message to remove a node from a graph
+// removeNode is a client message to remove a node from a graph.
 type removeNode struct {
 	ID    string
 	Graph string
 }
 
-// renameNode is a client message to rename a node in a graph
+// renameNode is a client message to rename a node in a graph.
 type renameNode struct {
 	From  string
 	To    string
 	Graph string
 }
 
-// changeNode is a client message to change the metadata
-// associated to a node in the graph
+// changeNode is a client message to change the metadata associated with a node in the graph.
 type changeNode struct { // ignored
 	ID       string
 	Graph    string
 	Metadata map[string]interface{}
 }
 
-// addEdge is a client message to create a connection in a graph
+// addEdge is a client message to create a connection in a graph.
 type addEdge struct {
 	Src struct {
 		Node  string
@@ -101,7 +100,7 @@ type addEdge struct {
 	Metadata map[string]interface{} `json:",omitempty"` // ignored
 }
 
-// removeEdge is a client message to delete a connection from a graph
+// removeEdge is a client message to delete a connection from a graph.
 type removeEdge struct {
 	Src struct {
 		Node string
@@ -114,7 +113,7 @@ type removeEdge struct {
 	Graph string
 }
 
-// changeEdge is a client message to change connection metadata
+// changeEdge is a client message to change connection metadata.
 type changeEdge struct { // ignored
 	Src struct {
 		Node  string
@@ -130,7 +129,7 @@ type changeEdge struct { // ignored
 	Metadata map[string]interface{}
 }
 
-// addInitial is a client message to add an IIP to a graph
+// addInitial is a client message to add an IIP to a graph.
 type addInitial struct {
 	Src struct {
 		Data interface{}
@@ -144,7 +143,7 @@ type addInitial struct {
 	Metadata map[string]interface{} `json:",omitempty"` // ignored
 }
 
-// removeInitial is a client message to remove an IIP from a graph
+// removeInitial is a client message to remove an IIP from a graph.
 type removeInitial struct {
 	Tgt struct {
 		Node  string
@@ -154,7 +153,7 @@ type removeInitial struct {
 	Graph string
 }
 
-// addPort is a client message to add an exported inport/outport to the graph
+// addPort is a client message to add an exported inport/outport to the graph.
 type addPort struct {
 	Public   string
 	Node     string
@@ -163,13 +162,13 @@ type addPort struct {
 	Metadata map[string]interface{} `json:",omitempty"` // ignored
 }
 
-// removePort is a client message to remove an exported inport/outport from the graph
+// removePort is a client message to remove an exported inport/outport from the graph.
 type removePort struct {
 	Public string
 	Graph  string
 }
 
-// renamePort is a client message to rename a port of a graph
+// renamePort is a client message to rename a port of a graph.
 type renamePort struct {
 	From  string
 	To    string


### PR DESCRIPTION
I decided to enable and fix `godot` while browsing the code. You will also notice that I got slightly carried away and dropped the `Capacity` setting from the `GraphConfig`, which does not feel like a helpful optimization, but rather raises questions as to why all these capacities are created equal. I think Go runtime is more than capable of scaling all containers appropriately.

To be honest, I'm also not a big fan of the `GraphConfig.BufferSize`, but let's leave that aside for now.

I've also tried to slightly improve and add some comments here and there.